### PR TITLE
Add M5StickC PLUS2 runtime support

### DIFF
--- a/src/a_GLOBAL/a_GLOBAL.ino
+++ b/src/a_GLOBAL/a_GLOBAL.ino
@@ -36,4 +36,4 @@ int CONN_INT = 0;
 int MODE = 0; //0 for words like SAFE, PRE and LIVE. 1 for numbers with changing background
 int JUSTLIVE = 0; //When 1, SAFE and PRE are not used. Just the LIVE screen
 
-String semver = "2.5.0";
+String semver = "2.5.1";

--- a/src/a_GLOBAL/a_GLOBAL.ino
+++ b/src/a_GLOBAL/a_GLOBAL.ino
@@ -14,7 +14,11 @@
 #include <Preferences.h>
 #include "k_PLUGINMANAGER.h";
 
+#if C_PLUS == 2
+#define LED_BUILTIN 19
+#else
 #define LED_BUILTIN 10
+#endif
 
 int tnlen = 1; //LET THIS BE
 

--- a/src/a_GLOBAL/b_SETTINGS.ino
+++ b/src/a_GLOBAL/b_SETTINGS.ino
@@ -37,6 +37,8 @@ void loadSettings()
     BRIGHTNESS = preferences.getUInt("bright");
     #if C_PLUS == 0 || C_PLUS == 1
       M5.Axp.ScreenBreath((BRIGHTNESS-6)*16);
+    #else
+      M5.Lcd.setBrightness((BRIGHTNESS-7)*51);
     #endif
   }
   preferences.end();

--- a/src/a_GLOBAL/b_SETTINGS.ino
+++ b/src/a_GLOBAL/b_SETTINGS.ino
@@ -37,7 +37,7 @@ void loadSettings()
     BRIGHTNESS = preferences.getUInt("bright");
     #if C_PLUS == 0 || C_PLUS == 1
       M5.Axp.ScreenBreath((BRIGHTNESS-6)*16);
-    #else
+    #elif C_PLUS == 2
       M5.Lcd.setBrightness((BRIGHTNESS-7)*51);
     #endif
   }

--- a/src/a_GLOBAL/c_MAIN.ino
+++ b/src/a_GLOBAL/c_MAIN.ino
@@ -37,6 +37,11 @@ void setup()
   setCpuFrequencyMhz(80); //Thanks Irvin Cee
   Serial.begin(115200);
   M5.begin();
+
+#if C_PLUS == 2
+  pinMode(4, OUTPUT);
+  digitalWrite(4, HIGH);
+#endif
   
   #if C_PLUS == 0 || C_PLUS == 1
     M5.IMU.Init();

--- a/src/a_GLOBAL/c_MAIN.ino
+++ b/src/a_GLOBAL/c_MAIN.ino
@@ -207,7 +207,7 @@ void start()
   M5.Lcd.setRotation(screenRotation);
   
   String prod = "vMix M5Stick-C Tally";
-  String author = "by Guido Visser";
+  String author = "by Guido Visser/Kevin";
   
   M5.Lcd.setTextSize(1);
   M5.Lcd.setTextColor(WHITE, BLACK);

--- a/src/a_GLOBAL/j_BRIGHTNESSSCREEN.ino
+++ b/src/a_GLOBAL/j_BRIGHTNESSSCREEN.ino
@@ -54,6 +54,8 @@ void updateBrightnessVar(){
 void updateBrightness(){
   #if C_PLUS == 0 || C_PLUS == 1
     M5.Axp.ScreenBreath((BRIGHTNESS-6)*16);
+  #else
+    M5.Lcd.setBrightness((BRIGHTNESS-7)*51);
   #endif
   saveBrightness();
 }

--- a/src/a_GLOBAL/j_BRIGHTNESSSCREEN.ino
+++ b/src/a_GLOBAL/j_BRIGHTNESSSCREEN.ino
@@ -54,7 +54,7 @@ void updateBrightnessVar(){
 void updateBrightness(){
   #if C_PLUS == 0 || C_PLUS == 1
     M5.Axp.ScreenBreath((BRIGHTNESS-6)*16);
-  #else
+  #elif C_PLUS == 2
     M5.Lcd.setBrightness((BRIGHTNESS-7)*51);
   #endif
   saveBrightness();


### PR DESCRIPTION
## Summary
- support the M5StickC PLUS2 board
- handle brightness for PLUS2 displays
- keep power on by raising GPIO4
- adjust builtin LED pin for PLUS2

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852a6f1f33c832ba7e9f0b15008d0c0